### PR TITLE
Fixed loading issue with lanes

### DIFF
--- a/Assets/Scripts/PropScripts/Prop.cs
+++ b/Assets/Scripts/PropScripts/Prop.cs
@@ -63,7 +63,7 @@ public class Prop : MonoBehaviour
         string propType = gameObject.name;
         while (propType.EndsWith("(Clone)"))
         {
-            propType = propType.Substring(0, gameObject.name.Length - 7);
+            propType = propType.Substring(0, propType.Length - 7);
         }
         return propType;
     }

--- a/Assets/Scripts/RoadScripts/LaneScripts/BasicLane.cs
+++ b/Assets/Scripts/RoadScripts/LaneScripts/BasicLane.cs
@@ -10,7 +10,6 @@ public class BasicLane : MonoBehaviour
     [SerializeField] private const float DEFAULT_LANE_WIDTH_FT = 12.0f;
     [SerializeField] protected GameObject asphalt;
     [SerializeField] protected int laneIndex;
-    [SerializeField] protected string laneType;
     [SerializeField] protected float currentLaneWidth;
     [SerializeField] protected float maxWidth;
     [SerializeField] protected float minWidth;
@@ -167,16 +166,14 @@ public class BasicLane : MonoBehaviour
     }
 
     // Nathan wrote this
-    // sets the lane's current type
-    public void setLaneType(string newTypeName)
-    {
-        laneType = newTypeName;
-    }
-
-    // Nathan wrote this
     // retrieves lane's current type
     public string getLaneType()
     {
+        string laneType = gameObject.name;
+        while (laneType.EndsWith("(Clone)"))
+        {
+            laneType = laneType.Substring(0, laneType.Length - 7);
+        }
         return laneType;
     }
 

--- a/Assets/Scripts/RoadScripts/Road.cs
+++ b/Assets/Scripts/RoadScripts/Road.cs
@@ -287,8 +287,6 @@ public class Road : MonoBehaviour
         LinkedListNode<GameObject> newLaneNode = laneNode.Next;
         GameObject newLane = newLaneNode.Value;
         BasicLane newLaneScript = (BasicLane)newLane.GetComponent("BasicLane");
-        // reset the name of the lane
-        newLaneScript.setLaneType(newType);
         // 4. delete the old lane 
         removeLane(targetLane);
         // 5. adjust the stripes of the new lane


### PR DESCRIPTION
- changed getLaneType() in BasicLane.cs to return the objects name minus the (Clone)
- updated Prop.cs similar function to be based on the string instead of the original object name as a double (Clone) would cause an out of bounds exception
- removed setLaneType() in BasicLane as well as the laneType string
- removed the reference to setLaneType() in Road.cs